### PR TITLE
Build & Deploy website

### DIFF
--- a/.github/workflows/deploy_website.yaml
+++ b/.github/workflows/deploy_website.yaml
@@ -1,0 +1,41 @@
+name: Deploy MPC-Framework website
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-artifacts:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::490752553772:role/mpc-framework-website-assume_role-slc
+          role-duration-seconds: 900
+          aws-region: eu-central-1
+
+      - name: Install dependencies
+        run: |
+          npm i
+
+      - name: Build
+        run: |
+          npm run build
+
+      - name: Upload artifacts
+        run: |
+          aws s3 sync ./build/ s3://mpc-framework-website --delete

--- a/.github/workflows/deploy_website.yaml
+++ b/.github/workflows/deploy_website.yaml
@@ -1,4 +1,4 @@
-name: Deploy MPC Framework website
+name: Deploy website
 on:
   push:
     branches:

--- a/.github/workflows/deploy_website.yaml
+++ b/.github/workflows/deploy_website.yaml
@@ -1,4 +1,4 @@
-name: Deploy MPC-Framework website
+name: Deploy MPC Framework website
 on:
   push:
     branches:


### PR DESCRIPTION
## What is this PR doing?
With this PR, a new GH Actions workflow is introduced that builds and deploys the website artifacts to an S3 bucket.

Some details about the infrastructure: The S3 bucket is not publicly accessible and only allows access from a specific CloudFront distribution. The workflow uses short-lived credentials with policies that are limited to allowing access to this bucket, and only this repository can assume that role.

URL: https://mpc.pse.dev/

## Checklist

- [X] I have manually tested these changes
- [ ] Post a link to the PR in the group chat